### PR TITLE
remove unuse module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var fs = require('fs'),
     through2 = require('through2'),
     gutil = require('gulp-util'),
-    tempfile = require('tempfile'),
     HTMLHint = require('htmlhint').HTMLHint,
     PluginError = gutil.PluginError;
 


### PR DESCRIPTION
raise error

```sh
module.js:338
    throw err;
          ^
Error: Cannot find module 'tempfile'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/miyamoto/.ghq/ghe.tokyo.pb/lolipop/lolipop-www/node_modules/gulp-htmlhint-inline/index.js:4:16)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```
---

Remove unuse module ```tempfile```