### PR TITLE
add error report with file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ gulpHtmlhintInline.defaultReporter = function(file) {
     if(report.success) { log(color.green(file.path + ' lint free.')); }
 
     if(!report.success) {
-        log(color.cyan(report.length) + ' error' + (report.length === 1 ? '' : 's') + ' found');
+        log(color.cyan(report.length) + ' error' + (report.length === 1 ? '' : 's') + ' found at ' + color.gray(file.path));
 
         report.forEach(function(message) {
             var evidence = message.evidence,
@@ -176,7 +176,7 @@ gulpHtmlhintInline.failReporter = function() {
         (fails = fails || []).push(file.path);
 
         if(file.htmlhint_inline && file.htmlhint_inline.length !== 0) {
-            error =  new PluginError(PLUGIN_NAME, {
+            error = new PluginError(PLUGIN_NAME, {
                 message: PLUGIN_NAME + ' failed for: ' + fails.join(', '),
                 showStack: false
             });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-htmlhint-inline",
   "description": "Gulp plugin for linting inline html",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "homepage": "https://github.com/kazu69/gulp-htmlhint-inline",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
- bump up v0.0.7
- error report with file path.
see blow

```sh
14:52:12] Using gulpfile gulp-htmlhint-inline/gulpfile.js
[14:52:12] Starting 'lint'...
[14:52:12] Finished 'lint' after 141 ms
[14:52:12] Starting 'test'...
[14:52:12] 1 error found at gulp-htmlhint-inline/test/index.phtml
[14:52:12] [L 37:C1] Tag must be paired, missing: [ </p> ], start tag match failed [ <p> ] on line 21.
[14:52:12] </body>
[14:52:12] 'test' errored after 18 ms
[14:52:12] Error in plugin 'gulp-htmlhint-inline'
Message:
    gulp-htmlhint-inline failed for: gulp-htmlhint-inline/test/index.phtml
npm ERR! Test failed.  See above for more details.
```

```
1 error found at gulp-htmlhint-inline/test/index.phtml
```